### PR TITLE
Role caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sensate-dashboard",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sensate-dashboard",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/services/account.service.ts
+++ b/src/app/services/account.service.ts
@@ -136,7 +136,15 @@ export class AccountService {
     const roles = localStorage.getItem('roles');
     const admin = localStorage.getItem('admin');
 
-    return roles != null && admin != null;
+    if(roles == null) {
+      return false;
+    }
+
+    if(value.roles.indexOf('Administrators') >= 0) {
+      localStorage.setItem('admin', 'true');
+    }
+
+    return true;
   }
 
   public static isAdmin() : boolean {


### PR DESCRIPTION
Correctly cache roles for non-admin uses by not taking the administrator
flag into consideration when caching roles.